### PR TITLE
Use test adzerk account in staging

### DIFF
--- a/load/stitch_finder.rb
+++ b/load/stitch_finder.rb
@@ -8,13 +8,13 @@ class StitchFinder
 
   DOVETAIL_REQUEST_LIMIT = 10
 
-  DOVETAIL_FEEDS = %w(
-    http://feeder-staging.prx.tech/podcasts/23
-    http://feeder-staging.prx.tech/podcasts/13
-    http://feeder-staging.prx.tech/podcasts/24
-    http://feeder-staging.prx.tech/podcasts/18
-    http://feeder-staging.prx.tech/podcasts/23
-  )
+  DOVETAIL_FEEDS = [
+    'http://feeder-staging.prx.tech/podcasts/23', # 99pi
+    'http://feeder-staging.prx.tech/podcasts/13', # serial
+    'http://feeder-staging.prx.tech/podcasts/24', # themoth
+    'http://feeder-staging.prx.tech/podcasts/18', # criminal
+    'http://feeder-staging.prx.tech/podcasts/3',  # memory
+  ]
 
   attr_reader :stitches
 
@@ -53,7 +53,13 @@ class StitchFinder
         end
         threads << Thread.new do
           resp = http_unique.get("#{DOVETAIL_HOST}/#{path}?noImp")
-          if resp.headers['Location'][0..2] == '/+/'
+          if resp.status == 404
+            path.gsub!(/^\//, '/prod_') # try the prod_ program key
+            resp = http_unique.get("#{DOVETAIL_HOST}/#{path}?noImp")
+          end
+          if resp.status != 302
+            puts "error: #{resp.status} from #{path}"
+          elsif resp.headers['Location'][0..2] == '/+/'
             locations << resp.headers['Location']
           elsif resp.headers['Location'] =~ /^.+cdn[^.]*.prxu\.org\//
             locations << resp.headers['Location'].gsub(/^.+cdn[^.]*.prxu\.org\//, '/+/')

--- a/test/dovetail/programs_test.rb
+++ b/test/dovetail/programs_test.rb
@@ -3,34 +3,46 @@ require 'digest'
 
 describe 'dovetail-programs' do
 
-  MAX_RETRIES = 5
-
   EPISODES = {
-    'criminal' => 'criminal/23166e58-e181-4c03-b52d-6f6746a1bced/Episode_35__Pen_and_Paper.mp3',
-    'memory'   => 'memory/c9dfaa10-7b21-4804-9d5e-7f55dfbefc24/thememorypalace.mp3',
-    'serial'   => 'serial/b10f2326-b3b9-478e-a74d-22c460946316/serial-s02-e05.mp3',
+    'criminal' => 'prod_criminal/23166e58-e181-4c03-b52d-6f6746a1bced/Episode_35__Pen_and_Paper.mp3',
+    'memory'   => 'prod_memory/c9dfaa10-7b21-4804-9d5e-7f55dfbefc24/thememorypalace.mp3',
+    'serial'   => 'prod_serial/b10f2326-b3b9-478e-a74d-22c460946316/serial-s02-e05.mp3',
   }
+  NEW_THREADS = {}
+  NEW_DOWNLOADS = {}
+  PROD_THREADS = {}
+  PROD_DOWNLOADS = {}
 
   def http_unique
     HTTP.headers('user-agent' => "meta.prx.org tests #{SecureRandom.uuid}")
   end
 
-  # find the same stitch in both new and old (prod) environments
-  def get_stitch_in_both_envs(name, path, attempt = 1)
-    redirect = http_unique.get("#{DOVETAIL_HOST}/#{path}?noImp")
-    redirect.status.must_equal 302
-    redirect.headers['x-not-impressed'].must_equal 'yes'
-    redirect.headers['location'].must_include "/#{name}/"
-    location = "/+/#{name}/" + redirect.headers['location'].split("/#{name}/").last
+  def tmp_file(program, filename)
+    tmp_dir = "#{File.dirname(__FILE__)}/../../tmp"
+    Dir.mkdir(tmp_dir) unless Dir.exists?(tmp_dir)
+    "#{tmp_dir}/#{program}.#{filename}"
+  end
 
-    # attempt to get prod version
-    prod_stitch = HTTP.get(DOVETAIL_PROD + location)
-    if prod_stitch.status == 404 && attempt < MAX_RETRIES
-      warn "  stitch #{location} not found in prod - retrying ..."
-      return get_stitch_in_both_envs(name, path, attempt + 1)
-    else
-      stitch = HTTP.get(DOVETAIL_HOST + location)
-      return [stitch, prod_stitch]
+  before do
+    if NEW_THREADS.empty?
+      EPISODES.each do |name, path|
+        redirect = http_unique.get("#{DOVETAIL_HOST}/#{path}?noImp")
+        redirect.status.must_equal 302
+        redirect.headers['x-not-impressed'].must_equal 'yes'
+        redirect.headers['location'].must_include "/prod_#{name}/"
+
+        # digests SHOULD exist in prod, assuming (1) it's an older episode and
+        # (2) both environments are using the same SECRET_KEY
+        path = "/+/prod_#{name}/" + redirect.headers['location'].split("/prod_#{name}/").last
+        NEW_THREADS[name] = Thread.new do
+          NEW_DOWNLOADS[name] = HTTP.get(DOVETAIL_HOST + path)
+          File.open(tmp_file(name, 'new.mp3'), 'wb') {|f| f.write(NEW_DOWNLOADS[name].body) }
+        end
+        PROD_THREADS[name] = Thread.new do
+          PROD_DOWNLOADS[name] = HTTP.get(DOVETAIL_PROD + path.gsub('/prod_', '/'))
+          File.open(tmp_file(name, 'old.mp3'), 'wb') {|f| f.write(PROD_DOWNLOADS[name].body) }
+        end
+      end
     end
   end
 
@@ -39,7 +51,10 @@ describe 'dovetail-programs' do
     describe name do
 
       it 'matches the production mp3' do
-        new_stitch, old_stitch = get_stitch_in_both_envs(name, path)
+        NEW_THREADS[name].join
+        PROD_THREADS[name].join
+        new_stitch, old_stitch = [NEW_DOWNLOADS[name], PROD_DOWNLOADS[name]]
+
         new_stitch.status.must_equal 200
         new_stitch.headers['content-disposition'].must_equal 'attachment'
         new_stitch.headers['content-type'].must_equal 'audio/mpeg'
@@ -47,12 +62,8 @@ describe 'dovetail-programs' do
         old_stitch.headers['content-disposition'].must_equal 'attachment'
         old_stitch.headers['content-type'].must_equal 'audio/mpeg'
 
-        tmp_dir = "#{File.dirname(__FILE__)}/../../tmp"
-        new_file = "#{tmp_dir}/#{name}.new.mp3"
-        old_file = "#{tmp_dir}/#{name}.old.mp3"
-        Dir.mkdir(tmp_dir) unless Dir.exists?(tmp_dir)
-        File.open(new_file, 'wb') {|f| f.write(new_stitch.body) }
-        File.open(old_file, 'wb') {|f| f.write(old_stitch.body) }
+        new_file = tmp_file(name, 'new.mp3')
+        old_file = tmp_file(name, 'old.mp3')
 
         # compare the ffprobe output first
         new_probe = `ffprobe #{new_file} 2>&1`.gsub(/.+#{name}.new.mp3':\n/m, '')


### PR DESCRIPTION
Uses the new prod-program-in-staging names, like `prod_serial` instead of `serial`.  Allows the acceptance and load tests to work against staging after we move to the test adzerk account there.

Also multithreads the acceptance tests to make them download a bit faster.