### PR TITLE
Acceptance tests for upload lambda

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ bundle exec rake test
 # or run a single subset of tests
 bundle exec rake test:dovetail
 bundle exec rake test:publish
+bundle exec rake test:upload
 ```
 
 ### Load Tests

--- a/Rakefile
+++ b/Rakefile
@@ -30,5 +30,9 @@ Rake::TestTask.new('test:publish') do |t|
   t.libs << 'test/support'
   t.pattern = "test/publish/*_test.rb"
 end
+Rake::TestTask.new('test:upload') do |t|
+  t.libs << 'test/support'
+  t.pattern = "test/upload/*_test.rb"
+end
 
 task default: :test

--- a/env-example
+++ b/env-example
@@ -4,3 +4,4 @@ FEEDER_HOST=feeder-staging.prx.tech
 PUBLISH_HOST=publish-staging.prx.tech
 PUBLISH_USER=
 PUBLISH_PASS=
+UPLOAD_HOST=

--- a/test/support/config.rb
+++ b/test/support/config.rb
@@ -14,7 +14,9 @@ File.open("#{File.dirname(__FILE__)}/../../env-example", 'r').each_line do |line
     # add scheme and check connection to hosts
     if CONFIG[name] && name.match(/_HOST$/)
       if CONFIG[name][0..3] != 'http'
-        scheme = CONFIG[name].match(/.*\.prxu?\.(?:org|tech)$/) ? 'https' : 'http'
+        is_prx = CONFIG[name].match(/.*\.prxu?\.(?:org|tech)$/)
+        is_aws = CONFIG[name].match(/.*\.amazonaws\./)
+        scheme = is_prx || is_aws ? 'https' : 'http'
         CONFIG[name] = "#{scheme}://#{CONFIG[name]}"
       end
       begin

--- a/test/upload/signature_test.rb
+++ b/test/upload/signature_test.rb
@@ -12,7 +12,7 @@ require 'test_helper'
 
    it 'return plain text media type' do
      resp = connection.get(query: {to_sign: 'hello'})
-     resp.headers['content-type'].must_equal 'text/plain'
+     resp.headers['Content-Type'].must_equal 'text/plain'
    end
 
    it 'return to correct signature' do
@@ -23,5 +23,7 @@ require 'test_helper'
    it 'enables CORS' do
      resp = Excon.options(CONFIG.UPLOAD_HOST)
      resp.status.wont_equal 403
+     resp.headers['Access-Control-Allow-Methods'].must_include 'GET'
+     resp.headers['Access-Control-Allow-Origin'].must_equal '*'
    end
  end

--- a/test/upload/signature_test.rb
+++ b/test/upload/signature_test.rb
@@ -1,19 +1,19 @@
 require 'test_helper'
 
  describe 'upload-signature' do
+   let(:connection) { connection = Excon.new(CONFIG.UPLOAD_HOST) }
+
    it 'returns 400 with nothing to sign' do
-     resp = Excon.get(CONFIG.UPLOAD_HOST)
+     resp = connection.get(query: {to_sign: ''})
      resp.status.must_equal 400
    end
 
    it 'return plain text media type' do
-     connection = Excon.new(CONFIG.UPLOAD_HOST)
      resp = connection.get(query: {to_sign: 'hello'})
      resp.headers['content-type'].must_equal 'text/plain'
    end
 
    it 'return to correct signature' do
-     connection = Excon.new(CONFIG.UPLOAD_HOST)
      resp = connection.get(query: {to_sign: 'test'})
      resp.body.to_s.must_equal "TyhhPs0RA37JFn+0oWNdm25HgBc="
    end

--- a/test/upload/signature_test.rb
+++ b/test/upload/signature_test.rb
@@ -15,15 +15,16 @@ require 'test_helper'
      resp.headers['Content-Type'].must_equal 'text/plain'
    end
 
-   it 'return to correct signature' do
+   it 'return correct signature' do
      resp = connection.get(query: {to_sign: 'test'})
      resp.body.to_s.must_equal "TyhhPs0RA37JFn+0oWNdm25HgBc="
    end
 
    it 'enables CORS' do
-     resp = Excon.options(CONFIG.UPLOAD_HOST)
-     resp.status.wont_equal 403
+     resp = connection.options
+     resp.wont_be_nil
      resp.headers['Access-Control-Allow-Methods'].must_include 'GET'
+     resp.headers['Access-Control-Allow-Methods'].must_include 'OPTIONS'
      resp.headers['Access-Control-Allow-Origin'].must_equal '*'
    end
  end

--- a/test/upload/signature_test.rb
+++ b/test/upload/signature_test.rb
@@ -1,7 +1,9 @@
 require 'test_helper'
 
  describe 'upload-signature' do
-   let(:connection) { connection = Excon.new(CONFIG.UPLOAD_HOST) }
+   let(:connection) do
+     Excon.new("#{CONFIG.UPLOAD_HOST}/prod/signature")
+   end
 
    it 'returns 400 with nothing to sign' do
      resp = connection.get(query: {to_sign: ''})

--- a/test/upload/signature_test.rb
+++ b/test/upload/signature_test.rb
@@ -1,0 +1,25 @@
+require 'test_helper'
+
+ describe 'upload-signature' do
+   it 'returns 400 with nothing to sign' do
+     resp = Excon.get(CONFIG.UPLOAD_HOST)
+     resp.status.must_equal 400
+   end
+
+   it 'return plain text media type' do
+     connection = Excon.new(CONFIG.UPLOAD_HOST)
+     resp = connection.get(query: {to_sign: 'hello'})
+     resp.headers['content-type'].must_equal 'text/plain'
+   end
+
+   it 'return to correct signature' do
+     connection = Excon.new(CONFIG.UPLOAD_HOST)
+     resp = connection.get(query: {to_sign: 'test'})
+     resp.body.to_s.must_equal "TyhhPs0RA37JFn+0oWNdm25HgBc="
+   end
+
+   it 'enables CORS' do
+     resp = Excon.options(CONFIG.UPLOAD_HOST)
+     resp.status.wont_equal 403
+   end
+ end


### PR DESCRIPTION
Followed up on `feat/upload-signing-tests` and added a currently-failing test for CORS support (unless there's a clearer way to test that than directly calling OPTIONS on the api?)

Depends on: https://github.com/PRX/Infrastructure/pull/30 