### PR TITLE
Base docker image for codebuild

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+tmp/*
+.git
+.gitignore
+.bundle
+docker-compose.yml
+Dockerfile
+.env
+env-example
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+FROM ruby:2.3.1
+
+# ffmpeg from static build
+RUN apt-get update && \
+    apt-get install -y xz-utils && \
+    cd /root && \
+    wget -q https://johnvansickle.com/ffmpeg/builds/ffmpeg-git-64bit-static.tar.xz && \
+    tar xvJf ffmpeg-git-64bit-static.tar.xz && \
+    mv ffmpeg-git-*-64bit-static/ffmpeg ffmpeg-git-*-64bit-static/ffprobe /usr/local/bin && \
+    apt-get clean && \
+    rm -rf /root/ffmpeg* /var/lib/apt/lists/* /var/cache/apt/*
+
+# phantomjs
+RUN apt-get update && \
+    apt-get install -y libfreetype6 libfreetype6-dev libfontconfig1 libfontconfig1-dev && \
+    cd /root && \
+    wget -q https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 && \
+    tar xvjf phantomjs-2.1.1-linux-x86_64.tar.bz2 && \
+    mv phantomjs-*/bin/phantomjs /usr/local/bin && \
+    apt-get clean && \
+    rm -rf /root/phantomjs* /var/lib/apt/lists/* /var/cache/apt/*
+
+# pre-bundle dependencies
+WORKDIR /home
+ENV HOME=/home
+ADD Gemfile ./
+ADD Gemfile.lock ./
+RUN bundle install
+
+ENTRYPOINT [ "/bin/bash" ]

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,30 +1,11 @@
 version: 0.1
-environment_variables:
-  plaintext:
-    # FFPROBE_PATH: "bin/ffprobe"
-    FFMPEG_STATIC_DIR: ffmpeg-static
-    FFMPEG_BIN: https://johnvansickle.com/ffmpeg/releases/ffmpeg-release-64bit-static.tar.xz
-    BUILD_PHASE_MARKER: build_phase_complete
 phases:
-  # install:
-  #   commands:
-  #     - apt-get update -y
   pre_build:
     commands:
-      - mkdir $FFMPEG_STATIC_DIR
-      - curl -so ffmpeg.tar.xz $FFMPEG_BIN
-      - unxz ffmpeg.tar.xz
-      - tar xvf ffmpeg.tar -C ./$FFMPEG_STATIC_DIR --strip-components=1
       - bundle install
   build:
     commands:
       - bundle exec rake
-      # - touch $BUILD_PHASE_MARKER
-  # post_build:
-  #   commands:
-  #     - test -e $BUILD_PHASE_MARKER
 artifacts:
-  # It seems like CodePipeline and CodeBuild expect an artifact here. Currently
-  # we don't need any, so this is essentially a no-op.
   files:
     - README.md

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+prxmeta:
+  build: .
+  volumes:
+    - .:/home
+  env_file: .env
+  entrypoint: bundle exec rake
+  command: test


### PR DESCRIPTION
Creates a docker-image to run codebuilds in.  Currently pushed to ECR with the `meta.prx.org:latest` tag.  Docker image doesn't include any of the code ... just dependencies.

Note that the `buildspec.yml` isn't actually used in here.  The build commands are hardcoded in Infrastructure, at the moment.