### PR TITLE
Add CI support

### DIFF
--- a/buildspec-pipeline.yml
+++ b/buildspec-pipeline.yml
@@ -1,0 +1,21 @@
+version: 0.2
+env:
+  parameter-store:
+    DOVETAIL_HOST: "/prx/test/meta.prx.org/DOVETAIL_HOST"
+    DOVETAIL_PROD_HOST: "/prx/test/meta.prx.org/DOVETAIL_PROD_HOST"
+    FEEDER_HOST: "/prx/test/meta.prx.org/FEEDER_HOST"
+    METRICS_HOST: "/prx/test/meta.prx.org/METRICS_HOST"
+    PUBLISH_HOST: "/prx/test/meta.prx.org/PUBLISH_HOST"
+    PUBLISH_PASS: "/prx/test/meta.prx.org/PUBLISH_PASS"
+    PUBLISH_USER: "/prx/test/meta.prx.org/PUBLISH_USER"
+    UPLOAD_HOST: "/prx/test/meta.prx.org/UPLOAD_HOST"
+phases:
+  pre_build:
+    commands:
+      - bundle install
+  build:
+    commands:
+      - bundle exec rake
+artifacts:
+  files:
+    - README.md

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,4 +1,14 @@
-version: 0.1
+version: 0.2
+env:
+  variables:
+    DOVETAIL_HOST: "dovetail.staging.prxu.org"
+    DOVETAIL_PROD_HOST: "dovetail.prxu.org"
+    FEEDER_HOST: "feeder.staging.prx.tech"
+    METRICS_HOST: "metrics.staging.prx.tech"
+    PUBLISH_HOST: "publish.staging.prx.tech"
+    PUBLISH_USER: "test@test.com"
+    PUBLISH_PASS: "test1234"
+    UPLOAD_HOST: "upload-5e12hsv5dh-us-east-1.staging.prx.tech"
 phases:
   pre_build:
     commands:
@@ -6,6 +16,3 @@ phases:
   build:
     commands:
       - bundle exec rake
-artifacts:
-  files:
-    - README.md

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,3 +1,4 @@
+# CI always looks for this string: PRX_
 version: 0.2
 env:
   variables:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -1,15 +1,15 @@
 # CI always looks for this string: PRX_
 version: 0.2
 env:
-  variables:
-    DOVETAIL_HOST: "dovetail.staging.prxu.org"
-    DOVETAIL_PROD_HOST: "dovetail.prxu.org"
-    FEEDER_HOST: "feeder.staging.prx.tech"
-    METRICS_HOST: "metrics.staging.prx.tech"
-    PUBLISH_HOST: "publish.staging.prx.tech"
-    PUBLISH_USER: "test@test.com"
-    PUBLISH_PASS: "test1234"
-    UPLOAD_HOST: "upload-5e12hsv5dh-us-east-1.staging.prx.tech"
+  parameter-store:
+    DOVETAIL_HOST: "/prx/test/meta.prx.org/DOVETAIL_HOST"
+    DOVETAIL_PROD_HOST: "/prx/test/meta.prx.org/DOVETAIL_PROD_HOST"
+    FEEDER_HOST: "/prx/test/meta.prx.org/FEEDER_HOST"
+    METRICS_HOST: "/prx/test/meta.prx.org/METRICS_HOST"
+    PUBLISH_HOST: "/prx/test/meta.prx.org/PUBLISH_HOST"
+    PUBLISH_PASS: "/prx/test/meta.prx.org/PUBLISH_PASS"
+    PUBLISH_USER: "/prx/test/meta.prx.org/PUBLISH_USER"
+    UPLOAD_HOST: "/prx/test/meta.prx.org/UPLOAD_HOST"
 phases:
   install:
     commands:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -11,10 +11,13 @@ env:
     PUBLISH_PASS: "test1234"
     UPLOAD_HOST: "upload-5e12hsv5dh-us-east-1.staging.prx.tech"
 phases:
-  pre_build:
+  install:
     commands:
-      - "cd $(ls -d */|head -n 1)"
-      - bundle install
+      - 'echo "Installing docker-compose..."'
+      - 'COMPOSE="https://github.com/docker/compose/releases/download/1.11.2/docker-compose-$(uname -s)-$(uname -m)" && curl -sL $COMPOSE -o /usr/local/bin/docker-compose'
+      - "chmod +x /usr/local/bin/docker-compose"
   build:
     commands:
-      - bundle exec rake
+      - "cd $(ls -d */|head -n 1)"
+      - "docker-compose -f docker-compose-ci.yml build"
+      - "docker-compose -f docker-compose-ci.yml run test"

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -20,4 +20,4 @@ phases:
     commands:
       - "cd $(ls -d */|head -n 1)"
       - "docker-compose -f docker-compose-ci.yml build"
-      - "docker-compose -f docker-compose-ci.yml run test"
+      - "docker-compose -f docker-compose-ci.yml up"

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -20,7 +20,7 @@ phases:
     commands:
       - "cd $(ls -d */|head -n 1)"
       - "docker-compose -f docker-compose-ci.yml build"
-      - "docker-compose -f docker-compose-ci.yml up"
+      - "docker-compose -f docker-compose-ci.yml run meta"
   post_build:
     commands:
       - 'curl -sO "https://raw.githubusercontent.com/PRX/Infrastructure/master/ci/utility/post_build.sh" && chmod +x post_build.sh && bash ./post_build.sh'

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -13,6 +13,7 @@ env:
 phases:
   pre_build:
     commands:
+      - "cd $(ls -d */|head -n 1)"
       - bundle install
   build:
     commands:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -21,3 +21,6 @@ phases:
       - "cd $(ls -d */|head -n 1)"
       - "docker-compose -f docker-compose-ci.yml build"
       - "docker-compose -f docker-compose-ci.yml up"
+  post_build:
+    commands:
+      - 'curl -sO "https://raw.githubusercontent.com/PRX/Infrastructure/master/ci/utility/post_build.sh" && chmod +x post_build.sh && bash ./post_build.sh'

--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -4,3 +4,12 @@ prxmeta:
     - .:/home
   entrypoint: bundle exec rake
   command: test
+  environment:
+    - DOVETAIL_HOST
+    - DOVETAIL_PROD_HOST
+    - FEEDER_HOST
+    - METRICS_HOST
+    - PUBLISH_HOST
+    - PUBLISH_USER
+    - PUBLISH_PASS
+    - UPLOAD_HOST

--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -1,4 +1,4 @@
-prxmeta:
+meta:
   build: .
   volumes:
     - .:/home

--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -1,0 +1,6 @@
+prxmeta:
+  build: .
+  volumes:
+    - .:/home
+  entrypoint: bundle exec rake
+  command: test

--- a/test/upload/signature_test.rb
+++ b/test/upload/signature_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
  describe 'upload-signature' do
    let(:connection) do
-     Excon.new("#{CONFIG.UPLOAD_HOST}/signature")
+     Excon.new("#{CONFIG.UPLOAD_HOST}/prod/signature")
    end
 
    it 'returns 400 with nothing to sign' do

--- a/test/upload/signature_test.rb
+++ b/test/upload/signature_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
  describe 'upload-signature' do
    let(:connection) do
-     Excon.new("#{CONFIG.UPLOAD_HOST}/prod/signature")
+     Excon.new("#{CONFIG.UPLOAD_HOST}/signature")
    end
 
    it 'returns 400 with nothing to sign' do


### PR DESCRIPTION
This allows CI to test pull requests (like this one) so that one can be sure the acceptance test suite works prior to changes being pushed to the CD pipeline action.