### PR TITLE
Timeout errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,22 @@ bundle exec rake test:publish
 bundle exec rake test:upload
 ```
 
+Use the `PROFILE_TIME` environment variable to trigger profiling information as the tests run:
+```
+PROFILE_TIME=1 bundle exec rake test:metrics
+```
+
+Use the `DEBUG` environment variable to trigger additional output as the tests run:
+```
+DEBUG=1 bundle exec rake test:metrics
+```
+
+Use the `BLACKBOX` environment variable to trigger additional integration tests that rely
+on asynchronous, eventually consistent systems (as for publish.prx.org).
+```
+BLACKBOX=1 bundle exec rake test:publish
+```
+
 ### Load Tests
 
 Non-CI load testing is also housed in this repo.  To test dovetail, just run `bundle exec rake load:dovetail`.  You can also specify the total-stitch-requests to make, and the concurrency of downloads: `bundle exec rake load:dovetail[200,10]`.

--- a/test/metrics/basic_test.rb
+++ b/test/metrics/basic_test.rb
@@ -8,11 +8,15 @@ describe :metrics, :js do
     end
 
     it 'registers when podcast is played' do
+      skip "set BLACKBOX=1 to fully test integration environment" unless blackbox_required?
       random_str = SecureRandom.hex(10)
-      mp3 = setup_fixtures(random_str)
+      series_url = create_series!(random_str)
+      _episode_url = create_episode!(series_url, random_str) # return var currently unused
+      mp3 = publish_fetch_rss_media_url(series_url)
+
       visit mp3 # "play" the audio
 
-      visit CONFIG.METRICS_HOST
+      visit metrics_url(series_url)
       page.must_have_content "Test Series #{random_str}"
       page.must_have_content "Test Episode #{random_str}"
 
@@ -28,11 +32,10 @@ describe :metrics, :js do
       end
       assert(found_episode_plays, 'found episode plays')
     end
+  end
 
-    def setup_fixtures(random_str)
-      series_url = create_series!(random_str)
-      create_episode!(series_url, random_str)
-      publish_fetch_rss_media_url(series_url)
-    end
+  def metrics_url(series_url)
+    series_id = series_url.match(/series\/(\d+)/)[1]
+    CONFIG.METRICS_HOST + "/#{series_id}/downloads/episodes/daily"
   end
 end

--- a/test/publish/basic_test.rb
+++ b/test/publish/basic_test.rb
@@ -23,6 +23,7 @@ describe :publish, :js do
     end
 
     it 'creates new episode with RSS feed' do
+      skip "set BLACKBOX=1 to fully test integration environment" unless blackbox_required?
       random_str = SecureRandom.hex(10)
       series_url = create_series!(random_str)
       series_url.must_match(/\/series\/\d+/)

--- a/test/support/publish_dsl.rb
+++ b/test/support/publish_dsl.rb
@@ -51,6 +51,7 @@ module Publish
     end
 
     def delete_test_series_and_episodes!
+      skip "set BLACKBOX=1 to fully test integration environment" unless blackbox_required?
       publish_login!
       ttl_start = Time.now
       start = profile_time(ttl_start, 'Deleting test series and episodes - start')
@@ -317,6 +318,14 @@ module Publish
 
     def debug?
       ENV['DEBUG'] == '1'
+    end
+
+    def blackbox_required?
+      unless ENV['BLACKBOX']
+        puts "set BLACKBOX=1 to run expensive integration tests"
+        return false
+      end
+      return true
     end
   end
 end


### PR DESCRIPTION
By default, all expensive integration tests are now skipped, until such time as we can make them less expensive.

To run them, add the `BLACKBOX=1` environment variable.

Adds documentation for the supported environment variables.