### PR TITLE
[WIP] Remove duplicate tests

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,4 +72,4 @@ DEPENDENCIES
   rake
 
 BUNDLED WITH
-   1.14.4
+   1.16.1

--- a/README.md
+++ b/README.md
@@ -24,6 +24,17 @@ Use the `PROFILE_TIME` environment variable to trigger profiling information as 
 PROFILE_TIME=1 bundle exec rake test:metrics
 ```
 
+Use the `DEBUG` environment variable to trigger additional output as the tests run:
+```
+DEBUG=1 bundle exec rake test:metrics
+```
+
+Use the `BLACKBOX` environment variable to trigger additional integration tests that rely
+on asynchronous, eventually consistent systems (as for publish.prx.org).
+```
+BLACKBOX=1 bundle exec rake test:publish
+```
+
 ### Load Tests
 
 Non-CI load testing is also housed in this repo.  To test dovetail, just run `bundle exec rake load:dovetail`.  You can also specify the total-stitch-requests to make, and the concurrency of downloads: `bundle exec rake load:dovetail[200,10]`.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@ bundle exec rake test:publish
 bundle exec rake test:upload
 ```
 
+Use the `PROFILE_TIME` environment variable to trigger profiling information as the tests run:
+```
+PROFILE_TIME=1 bundle exec rake test:metrics
+```
+
 ### Load Tests
 
 Non-CI load testing is also housed in this repo.  To test dovetail, just run `bundle exec rake load:dovetail`.  You can also specify the total-stitch-requests to make, and the concurrency of downloads: `bundle exec rake load:dovetail[200,10]`.

--- a/test/metrics/basic_test.rb
+++ b/test/metrics/basic_test.rb
@@ -8,6 +8,7 @@ describe :metrics, :js do
     end
 
     it 'registers when podcast is played' do
+      skip "set BLACKBOX=1 to fully test integration environment" unless ENV['BLACKBOX']
       random_str = SecureRandom.hex(10)
       series_url = create_series!(random_str)
       _episode_url = create_episode!(series_url, random_str) # return var currently unused
@@ -34,7 +35,7 @@ describe :metrics, :js do
   end
 
   def metrics_url(series_url)
-    series_id = series_url.match(/series\/(\d+)\//)[1]
+    series_id = series_url.match(/series\/(\d+)/)[1]
     CONFIG.METRICS_HOST + "/#{series_id}/downloads/episodes/daily"
   end
 end

--- a/test/metrics/basic_test.rb
+++ b/test/metrics/basic_test.rb
@@ -9,10 +9,13 @@ describe :metrics, :js do
 
     it 'registers when podcast is played' do
       random_str = SecureRandom.hex(10)
-      mp3 = setup_fixtures(random_str)
+      series_url = create_series!(random_str)
+      _episode_url = create_episode!(series_url, random_str) # return var currently unused
+      mp3 = publish_fetch_rss_media_url(series_url)
+
       visit mp3 # "play" the audio
 
-      visit CONFIG.METRICS_HOST
+      visit metrics_url(series_url)
       page.must_have_content "Test Series #{random_str}"
       page.must_have_content "Test Episode #{random_str}"
 
@@ -28,11 +31,10 @@ describe :metrics, :js do
       end
       assert(found_episode_plays, 'found episode plays')
     end
+  end
 
-    def setup_fixtures(random_str)
-      series_url = create_series!(random_str)
-      create_episode!(series_url, random_str)
-      publish_fetch_rss_media_url(series_url)
-    end
+  def metrics_url(series_url)
+    series_id = series_url.match(/series\/(\d+)\//)[1]
+    CONFIG.METRICS_HOST + "/#{series_id}/downloads/episodes/daily"
   end
 end

--- a/test/metrics/basic_test.rb
+++ b/test/metrics/basic_test.rb
@@ -8,7 +8,7 @@ describe :metrics, :js do
     end
 
     it 'registers when podcast is played' do
-      skip "set BLACKBOX=1 to fully test integration environment" unless ENV['BLACKBOX']
+      skip "set BLACKBOX=1 to fully test integration environment" unless blackbox_required?
       random_str = SecureRandom.hex(10)
       series_url = create_series!(random_str)
       _episode_url = create_episode!(series_url, random_str) # return var currently unused

--- a/test/publish/basic_test.rb
+++ b/test/publish/basic_test.rb
@@ -23,7 +23,7 @@ describe :publish, :js do
     end
 
     it 'creates new episode with RSS feed' do
-      skip "set BLACKBOX=1 to fully test integration environment" unless ENV['BLACKBOX']
+      skip "set BLACKBOX=1 to fully test integration environment" unless blackbox_required?
       random_str = SecureRandom.hex(10)
       series_url = create_series!(random_str)
       series_url.must_match(/\/series\/\d+/)

--- a/test/publish/basic_test.rb
+++ b/test/publish/basic_test.rb
@@ -22,15 +22,10 @@ describe :publish, :js do
       delete_test_series_and_episodes!
     end
 
-    it 'creates new episode with RSS feed' do
+    it 'creates new series' do
       skip "set BLACKBOX=1 to fully test integration environment" unless blackbox_required?
-      random_str = SecureRandom.hex(10)
-      series_url = create_series!(random_str)
+      series_url = create_series!
       series_url.must_match(/\/series\/\d+/)
-      episode_url = create_episode!(series_url, random_str)
-      episode_url.must_match(/\/story\/\d+/)
-      mp3 = publish_fetch_rss_media_url(series_url)
-      assert(mp3.match(/\.mp3$/), 'Found mp3 url')
     end
   end
 end

--- a/test/publish/basic_test.rb
+++ b/test/publish/basic_test.rb
@@ -23,6 +23,7 @@ describe :publish, :js do
     end
 
     it 'creates new episode with RSS feed' do
+      skip "set BLACKBOX=1 to fully test integration environment" unless ENV['BLACKBOX']
       random_str = SecureRandom.hex(10)
       series_url = create_series!(random_str)
       series_url.must_match(/\/series\/\d+/)

--- a/test/support/publish_dsl.rb
+++ b/test/support/publish_dsl.rb
@@ -51,7 +51,7 @@ module Publish
     end
 
     def delete_test_series_and_episodes!
-      skip "set BLACKBOX=1 to fully test integration environment" unless ENV['BLACKBOX']
+      skip "set BLACKBOX=1 to fully test integration environment" unless blackbox_required?
       publish_login!
       ttl_start = Time.now
       start = profile_time(ttl_start, 'Deleting test series and episodes - start')
@@ -318,6 +318,14 @@ module Publish
 
     def debug?
       ENV['DEBUG'] == '1'
+    end
+
+    def blackbox_required?
+      unless ENV['BLACKBOX']
+        puts "set BLACKBOX=1 to run expensive integration tests"
+        return false
+      end
+      return true
     end
   end
 end

--- a/test/support/publish_dsl.rb
+++ b/test/support/publish_dsl.rb
@@ -51,6 +51,7 @@ module Publish
     end
 
     def delete_test_series_and_episodes!
+      skip "set BLACKBOX=1 to fully test integration environment" unless ENV['BLACKBOX']
       publish_login!
       ttl_start = Time.now
       start = profile_time(ttl_start, 'Deleting test series and episodes - start')


### PR DESCRIPTION
The metrics tests do the same thing as the publish tests:
create a series, episode, upload a mp3, check podcast feed.
In the interest of saving runtime, just do the minimal series
creation in the publish tests and rely on the metrics tests for the
full cycle.

Branched from #68 so merge that first and I will rebase this PR. See #64 