### PR TITLE
Fix metrics basic test 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.3.1
+FROM ruby:2.3.6
 
 # ffmpeg from static build
 RUN apt-get update && \
@@ -14,7 +14,7 @@ RUN apt-get update && \
 RUN apt-get update && \
     apt-get install -y libfreetype6 libfreetype6-dev libfontconfig1 libfontconfig1-dev && \
     cd /root && \
-    wget -q https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 && \
+    wget --local-encoding=utf-8 -q https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 && \
     tar xvjf phantomjs-2.1.1-linux-x86_64.tar.bz2 && \
     mv phantomjs-*/bin/phantomjs /usr/local/bin && \
     apt-get clean && \

--- a/test/metrics/basic_test.rb
+++ b/test/metrics/basic_test.rb
@@ -21,7 +21,7 @@ describe :metrics, :js do
       # our test series reported (as above)?
 
       found_episode_plays = false
-      tbody = find('metrics-downloads-table div.table-wrapper table.scroll-x tbody')
+      tbody = find('metrics-downloads-table div.table-wrapper table.sticky tbody')
       tbody.all('tr').each do |tr|
         found_episode_plays = true
         #tr.text.must_match(/ [1-9]+ /) # non-zero number of plays - TODO see comment above re: wait time.


### PR DESCRIPTION
`table.scroll-x` is now hidden by default after [the metrics summary table](https://github.com/PRX/metrics.prx.org/pull/151/files); instead now we'll look for the summary table, which is `table.sticky`