### PR TITLE
Remove duplicate tests from suite

### DIFF
--- a/test/publish/basic_test.rb
+++ b/test/publish/basic_test.rb
@@ -22,15 +22,10 @@ describe :publish, :js do
       delete_test_series_and_episodes!
     end
 
-    it 'creates new episode with RSS feed' do
+    it 'creates new series' do
       skip "set BLACKBOX=1 to fully test integration environment" unless blackbox_required?
-      random_str = SecureRandom.hex(10)
-      series_url = create_series!(random_str)
+      series_url = create_series!
       series_url.must_match(/\/series\/\d+/)
-      episode_url = create_episode!(series_url, random_str)
-      episode_url.must_match(/\/story\/\d+/)
-      mp3 = publish_fetch_rss_media_url(series_url)
-      assert(mp3.match(/\.mp3$/), 'Found mp3 url')
     end
   end
 end


### PR DESCRIPTION
The metrics tests do the same thing as the publish tests:
create a series, episode, upload a mp3, check podcast feed.
In the interest of saving runtime, just do the minimal series
creation in the publish tests and rely on the metrics tests for the
full cycle.